### PR TITLE
Add option to read API key from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ You can pass in options to the CLI. Here are the key ones:
 * `--disable-microphone` - disable the microphone.
 * `--clean` - clear credentials, and re-authenticate. Use this to switch projects or devices.
 * `--api-key <apikey>` - set an API key, useful for automatic authentication with a new project.
+* `--api-key-file <apikey-file>` - set an API key to a value read from file. This is useful for automatic authentication with a new project in environments where secrets are managed via files (e.g., Docker compose, Docker Swarm, Kubernetes).
 * `--greengrass` - utilize the AWS IoT Greengrass authentication context and AWS Secrets Manager to authenticate with a new project. See additional Greegrass notes below.
 * `--help` - see all options.
 

--- a/cli/linux/runner.ts
+++ b/cli/linux/runner.ts
@@ -56,6 +56,7 @@ program
     .option('--model-file <file>', 'Specify model file (either path to .eim, or the socket on which the model is running), ' +
         'if not provided the model will be fetched from Edge Impulse')
     .option('--api-key <key>', 'API key to authenticate with Edge Impulse (overrides current credentials)')
+    .option('--api-key-file <file>', 'File to read the API key from -- to authenticate with Edge Impulse (overrides current credentials)')
     .option('--download <file>', 'Just download the model and store it on the file system')
     .option('--list-targets', 'List all supported targets and inference engines')
     .option('--force-target <target>', 'Do not autodetect the target system, but set it by hand (e.g. "runner-linux-aarch64")')
@@ -107,7 +108,7 @@ const silentArgv: boolean = !!program.silent;
 const quantizedArgv: boolean = !!program.quantized;
 const enableCameraArgv: boolean = !!program.enableCamera;
 const verboseArgv: boolean = !!program.verbose;
-const apiKeyArgv = <string | undefined>program.apiKey;
+const apiKeyArgv = <string | undefined>program.apiKey ?? fs.readFileSync(program.apiKeyFile, 'utf-8').trim() ?? undefined;
 const greengrassArgv: boolean = !!program.greengrass;
 const modelFileArgv = <string | undefined>program.modelFile;
 const downloadArgv = <string | undefined>program.download;


### PR DESCRIPTION
Hello. Passing the secrets trough the commandline is security risk as any user on the machine can read the secret while the container is running. Page is suggesting to run:
```
docker run --rm -it \
    -p 1337:1337 \
    public.ecr.aws/g7a8t7v6/inference-container:v1.82.6 \
        --api-key ei_TRUNCATED
        --run-http-server 1337
````

I ran it as jhenner and then as a guest I can observe the password while the container is running by:
```
guest@veverka:/home/jhenner$ ps aux | grep ei_
root      259970  0.0  0.0      0     0 ?        S    09:13   0:00 [irq/129-mei_me]
jhenner   400696  4.4  0.1 2100536 59460 pts/1   Sl+  22:05   0:18 podman run --rm -it -p 1337:1337 public.ecr.aws/g7a8t7v6/inference-container:v1.82.6 --api-key ei_TRUNCATED --run-http-server 1337
jhenner   400988  0.8  0.3 1378984 122572 pts/0  Ssl+ 22:06   0:03 node /app/linux/node/build/cli/linux/runner.js --api-key ei_TRUNCATED --run-http-server 1337
guest     402288  0.0  0.0 231400  2748 pts/2    S+   22:12   0:00 grep --color=auto ei_
```

The base for the fix I am proposing enables the user to pass the secret trough a file on the filesystem, effectively hiding it from the ps aux and when used with the docker/podman secrets, it won't be part of the image  as well as this file is mounted similarly as volume.

https://docs.docker.com/engine/swarm/secrets/

Another important aspect of this is that with the proper handling of the secrets, one can easily share the `compose.yml` file without exposing the secrets to the world which would be the case if the secret was passed as the command line parameter.